### PR TITLE
Change intern.js for Live and Local Testing, modify tests for Local Testing

### DIFF
--- a/Live Testing/tests/intern.js
+++ b/Live Testing/tests/intern.js
@@ -10,17 +10,15 @@ define({
   defaultTimeout: 300000,
 
   environments: [
-    { browser: 'Opera', browser_version: '12.16', os: 'Windows', os_version: '8.1' },
-    { browser: 'Firefox', browser_version: '40.0', os: 'Windows', os_version: 'XP' },
-    { browser: 'IE', browser_version: '8.0', os: 'Windows', os_version: '7' },
     { browser: 'Chrome', browser_version: '44.0', os: 'OS X', os_version: 'Yosemite' },
-    { browserName: 'android', platform: 'ANDROID', device: 'Samsung Galaxy S5' }
+    { browser: 'Firefox', browser_version: '40.0', os: 'Windows', os_version: 'XP' },
+    { browser: 'Opera', browser_version: '12.16', os: 'Windows', os_version: '8.1' },
+    { browser: 'IE', browser_version: '8.0', os: 'Windows', os_version: '7' }
   ],
 
   maxConcurrency: 2,
 
   tunnel: 'BrowserStackTunnel',
-  //tunnel: 'NullTunnel',
 
   tunnelOptions: {
     verbose: true,
@@ -28,7 +26,7 @@ define({
     accessKey: process.env.BROWSERSTACK_KEY
   },
 
-  reporters: [ 'Console' ],
+  reporters: [ 'Pretty' ],
 
   loaderOptions: {
     packages: null

--- a/Live Testing/tests/intern.js
+++ b/Live Testing/tests/intern.js
@@ -4,7 +4,9 @@ define({
   capabilities: {
     name: 'Sample Intern Live-Testing',
     build: 'build',
-    'browserstack.selenium-version': '2.45.0'
+    'browserstack.selenium-version': '2.45.0',
+    'browserstack.local': false,
+    fixSessionCapabilities: false
   },
 
   defaultTimeout: 300000,

--- a/Local Testing/app/index.html
+++ b/Local Testing/app/index.html
@@ -4,11 +4,11 @@
 
     <script>
       function myFunction(value) {
-        document.getElementById("output").innerHTML += value;
+        document.getElementById("output").innerHTML = value;
       }
     </script>
     <h3>Input:</h3>
-    <input type="text" name="inputText" onchange="myFunction(this.value)"></input><br>
+    <input type="text" name="inputText" onkeyup="myFunction(this.value)"></input><br>
     <br>
     <h1 id="output">Browser</h1>
   </body>

--- a/Local Testing/tests/intern.js
+++ b/Local Testing/tests/intern.js
@@ -5,7 +5,8 @@ define({
     name: 'Sample Intern Local-Testing',
     build: 'build',
     'browserstack.selenium-version': '2.45.0',
-    'browserstack.local': true
+    'browserstack.local': true,
+    fixSessionCapabilities: false
   },
 
   defaultTimeout: 300000,

--- a/Local Testing/tests/intern.js
+++ b/Local Testing/tests/intern.js
@@ -11,11 +11,10 @@ define({
   defaultTimeout: 300000,
 
   environments: [
-    { browser: 'Opera', browser_version: '12.16', os: 'Windows', os_version: '8.1' },
-    { browser: 'Firefox', browser_version: '40.0', os: 'Windows', os_version: 'XP' },
-    { browser: 'IE', browser_version: '8.0', os: 'Windows', os_version: '7' },
     { browser: 'Chrome', browser_version: '44.0', os: 'OS X', os_version: 'Yosemite' },
-    { browserName: 'android', platform: 'ANDROID', device: 'Samsung Galaxy S5' }
+    { browser: 'Firefox', browser_version: '40.0', os: 'Windows', os_version: 'XP' },
+    { browser: 'Opera', browser_version: '12.16', os: 'Windows', os_version: '8.1' },
+    { browser: 'IE', browser_version: '8.0', os: 'Windows', os_version: '7' }
   ],
 
   maxConcurrency: 2,
@@ -28,7 +27,7 @@ define({
     accessKey: process.env.BROWSERSTACK_KEY
   },
 
-  reporters: [ 'Console' ],
+  reporters: [ 'Pretty' ],
 
   loaderOptions: {
     packages: null

--- a/Local Testing/tests/utils.js
+++ b/Local Testing/tests/utils.js
@@ -11,7 +11,7 @@ define([
         .get(require.toUrl('app/index.html'))
         .findByCssSelector("input")
           .click()
-          .type('Stack')
+          .type('BrowserStack')
           .end()
         .findByCssSelector('h1')
           .click()

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Node and npm
 
 `git clone https://github.com/browserstack/intern-browserstack.git`
 
-`cd intern-browserstack/`
-
 ### BrowserSack Authentication
 
 Export the environment variables for the username and access key of your BrowserStack account.


### PR DESCRIPTION
This PR includes the following changes -

1. change default test reporter to 'Pretty'
2. change default set of browsers for testing
3. changed local tests a bit (use onkeyup instead of onchange)
4. changed README
5. Explicitly set Browserstack.local = false for Live Testing
6. Set fixSessionCapabilities to false for faster testing (resolves issues on some safari browsers on windows)